### PR TITLE
Revert "Revert "Use Julia 1.9 until GAP.jl is compatible with Julia master again""

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -183,7 +183,8 @@ WORKDIR /home/gap
 # create GAP user root
 RUN mkdir -p .gap/pkg
 
-RUN mkdir -p inst/julia-master && curl -L https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz | tar -xvz --strip-components=1 -C inst/julia-master
+# use Julia 1.9 until https://github.com/oscar-system/GAP.jl/issues/902 is fixed
+RUN mkdir -p inst/julia-master && curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.1-linux-x86_64.tar.gz | tar -xvz --strip-components=1 -C inst/julia-master
 
 ENV PATH /home/gap/inst/julia-master/bin:${PATH}
 


### PR DESCRIPTION
This reverts commit 6df7c7532c9e32a724751258b15c636af036f597.