### PR TITLE
Revert "Revert "Revert "Use Julia 1.9 until GAP.jl is compatible with Julia master again"""

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -183,8 +183,7 @@ WORKDIR /home/gap
 # create GAP user root
 RUN mkdir -p .gap/pkg
 
-# use Julia 1.9 until https://github.com/oscar-system/GAP.jl/issues/902 is fixed
-RUN mkdir -p inst/julia-master && curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.1-linux-x86_64.tar.gz | tar -xvz --strip-components=1 -C inst/julia-master
+RUN mkdir -p inst/julia-master && curl -L https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz | tar -xvz --strip-components=1 -C inst/julia-master
 
 ENV PATH /home/gap/inst/julia-master/bin:${PATH}
 


### PR DESCRIPTION
Reverts homalg-project/gap-docker-base#2.

Things should work again with https://github.com/JuliaPackaging/Yggdrasil/pull/6962 and https://github.com/JuliaPackaging/Yggdrasil/pull/6978 merged.

The title of the PR is getting a bit out of hand :D