### PR TITLE
Keep using ubuntu 22.04 for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 ENV LANG=C.UTF-8
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+docker build -t local-gap-docker-base:latest .


### PR DESCRIPTION
until we fix the resulted issues of installing arangodb in ubuntu 24.04