### PR TITLE
Hotfix for expired ArangoDB GPG key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:latest
 
 ENV LANG=C.UTF-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN    dpkg --add-architecture i386 \
     && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 
 RUN    curl -L https://download.arangodb.com/arangodb312/DEBIAN/Release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/arangodb.gpg \
-    && echo 'deb https://download.arangodb.com/arangodb312/DEBIAN/ /' > /etc/apt/sources.list.d/arangodb.list \
+    && echo 'deb [trusted=yes] https://download.arangodb.com/arangodb312/DEBIAN/ /' > /etc/apt/sources.list.d/arangodb.list \
     && apt-get update \
     && apt-get install arangodb3-client
 


### PR DESCRIPTION
The [failing docker build](https://github.com/homalg-project/gap-docker-base/actions/runs/23521179894) was not caused by the ubuntu version, hence I reverted my previous commit. The reason is that the ArangoDB signing key expired yesterday. Since the key was not yet updated on their site, _apt-get update_ is failing with EXPKEYSIG.

I modified the Dockerfile to bypass signature verification. This is a temporary to restore CI/CD functionality until they provide a valid release key.